### PR TITLE
Removed limit() method which no longer exists in Firebase API

### DIFF
--- a/src/FireCryptQuery.js
+++ b/src/FireCryptQuery.js
@@ -83,10 +83,6 @@ export default class FireCryptQuery {
     return this._delegate('limitToLast', arguments);
   }
 
-  limit() {
-    return this._delegate('limit', arguments);
-  }
-
   _delegate(methodName, args) {
     return new FireCryptQuery(this._originalRef[methodName].apply(this._query, args), this._order, this._originalRef, this._crypto);
   }


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pkaminski/firecrypt/8)
<!-- Reviewable:end -->
