### PR TITLE
Fix isEqual comparisons between queries and references.

### DIFF
--- a/src/FireCryptQuery.js
+++ b/src/FireCryptQuery.js
@@ -40,7 +40,7 @@ export default class FireCryptQuery {
    * @return {boolean} Whether the two queries are equivalent.
    */
   isEqual(otherQuery) {
-    return this._query.isEqual(otherQuery && otherQuery._query);
+    return this._query.isEqual(otherQuery && (otherQuery._query || otherQuery._ref));
   }
 
   /**

--- a/src/FireCryptReference.js
+++ b/src/FireCryptReference.js
@@ -122,7 +122,7 @@ export default class FireCryptReference {
    * @return {boolean} Whether the two references are equivalent.
    */
   isEqual(otherRef) {
-    return this._ref.isEqual(otherRef && otherRef._ref);
+    return this._ref.isEqual(otherRef && (otherRef._ref || otherRef._query));
   }
 
   /**


### PR DESCRIPTION
The Firebase API allows isEqual comparisons between queries and references, though they'll always return false.  On the other hand, it appears that it's very unhappy if you pass in `undefined` (though `null` is OK).  So let's extract either the underlying query or reference from the argument that got passed in, maintaining the original's behavior as much as possible.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Reviewable/firecrypt/28)
<!-- Reviewable:end -->
